### PR TITLE
feat: add missing shutdown methods to services

### DIFF
--- a/speedoflight/services/agent/agent_service.py
+++ b/speedoflight/services/agent/agent_service.py
@@ -85,3 +85,6 @@ class AgentService(BaseService):
 
         self._logger.info("Agent run completed.")
         self.safe_emit(AGENT_RUN_COMPLETED_SIGNAL)
+
+    def shutdown(self):
+        self._logger.info("Shutting down.")

--- a/speedoflight/services/configuration/configuration_service.py
+++ b/speedoflight/services/configuration/configuration_service.py
@@ -42,3 +42,6 @@ class ConfigurationService(BaseService):
             return default_config
         except Exception as e:
             raise Exception(f"Failed to create {self.CONFIG_FILE_PATH}: {str(e)}")
+
+    def shutdown(self):
+        self._logger.info("Shutting down.")


### PR DESCRIPTION
Implements missing shutdown methods for ConfigurationService and AgentService to satisfy the abstract method requirement from BaseService.

Both services now have simple no-op shutdown implementations that log shutdown messages as specified in the issue.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)