### PR TITLE
Add Ruff GitHub Actions workflow and formatting commands

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,15 @@
+name: Ruff
+on: [ push, pull_request ]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: "check"
+          src: "./speedoflight"
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check"
+          src: "./speedoflight"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Development Commands
 ```bash
-make lint       # Run ruff linter on speedoflight/
-make typecheck  # Run mypy type checker on speedoflight/
+make lint         # Run ruff linter on speedoflight/
+make format-check # Run ruff format check on speedoflight/
+make format-diff  # Show ruff format changes without applying them
+make typecheck    # Run mypy type checker on speedoflight/
 ```
 
 ## Code Style

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,11 @@ run:
 lint:
 	ruff check speedoflight/
 
+format-check:
+	ruff format --check speedoflight/
+
+format-diff:
+	ruff format --diff speedoflight/
+
 typecheck:
 	mypy speedoflight/


### PR DESCRIPTION
## Summary
• Add GitHub Actions workflow to enforce Ruff linting and formatting checks on PRs
• Add local development commands (format-check, format-diff) to Makefile for pre-push validation

## Test plan
- [ ] Verify GitHub Actions workflow runs on PR creation
- [ ] Test local Makefile commands: `make format-check` and `make format-diff`
- [ ] Confirm workflow blocks PR merging when Ruff checks fail

🤖 Generated with [Claude Code](https://claude.ai/code)