### PR TITLE
Add GTK source view dependency and ollama type config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You can extend its functionality using the [Model Context Protocol](https://mode
 Clone this repo, install the dependencies in a virtual environment, and launch the app with Python:
 
 ```bash
+$ sudo apt install gir1.2-gtksource-5
 $ git clone git@github.com:zugaldia/speedoflight.git
 $ cd speedoflight
 $ python3 -m venv venv

--- a/speedoflight/services/configuration/configuration_service.py
+++ b/speedoflight/services/configuration/configuration_service.py
@@ -14,6 +14,7 @@ llm = "ollama"
 [llms]
 
 [llms.ollama]
+type = "ollama"
 model = "mistral-small:latest"
 """.strip()
 


### PR DESCRIPTION
## Summary
- Add gir1.2-gtksource-5 installation instruction to README
- Add type field to ollama configuration in default config

## Test plan
- [ ] Verify README installation instructions are accurate
- [ ] Confirm ollama configuration loads correctly with type field

🤖 Generated with [Claude Code](https://claude.ai/code)